### PR TITLE
Fix null key algorithm in Maven plugin

### DIFF
--- a/certificate-generator-maven-plugin/src/main/java/io/smallrye/certs/maven/CertificateRequestParameter.java
+++ b/certificate-generator-maven-plugin/src/main/java/io/smallrye/certs/maven/CertificateRequestParameter.java
@@ -1,5 +1,6 @@
 package io.smallrye.certs.maven;
 
+import io.smallrye.certs.KeyAlgorithm;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.util.List;
@@ -77,6 +78,9 @@ public class CertificateRequestParameter {
     }
 
     public String getKeyAlgorithm() {
+        if (keyAlgorithm == null) {
+            return KeyAlgorithm.RSA_2048.name();
+        }
         return keyAlgorithm;
     }
 


### PR DESCRIPTION
Use RSA by default.

I don't know why the default value is not used, but the `if/then/else` fixes the issue. 